### PR TITLE
fix(postgresql): Database initialization on creation only

### DIFF
--- a/src/postgresql/install.sh
+++ b/src/postgresql/install.sh
@@ -59,16 +59,24 @@ setup_pq() {
 #!/bin/sh
 set -e
 
-chown -R postgres:postgres $PGDATA \
-    && chmod 0750 $PGDATA \
-    && version_major=$(psql --version | sed -z "s/psql (PostgreSQL) //g" | grep -Eo -m 1 "^([0-9]+)" | sed -z "s/-//g") \
-    && echo "listen_addresses = '*'" >> /etc/postgresql/${version_major}/main/postgresql.conf \
-    && echo "data_directory = '$PGDATA'" >> /etc/postgresql/${version_major}/main/postgresql.conf \
-    && echo "host   all all 0.0.0.0/0        trust" > /etc/postgresql/${version_major}/main/pg_hba.conf \
-    && echo "host   all all ::/0             trust" >> /etc/postgresql/${version_major}/main/pg_hba.conf \
-    && echo "host   all all ::1/128          trust" >> /etc/postgresql/${version_major}/main/pg_hba.conf \
-    && sudo -H -u postgres sh -c "/usr/lib/postgresql/${version_major}/bin/initdb -D $PGDATA --auth-local trust --auth-host scram-sha-256" \
-    && sudo /etc/init.d/postgresql start \
+version_major=$(psql --version | sed -z "s/psql (PostgreSQL) //g" | grep -Eo -m 1 "^([0-9]+)" | sed -z "s/-//g")
+
+if [ ! -f "$PGDATA/PG_VERSION" ]; then
+    echo "Initializing PostgreSQL database..."
+    chown -R postgres:postgres $PGDATA \
+        && chmod 0750 $PGDATA \
+        && echo "listen_addresses = '*'" >> /etc/postgresql/${version_major}/main/postgresql.conf \
+        && echo "data_directory = '$PGDATA'" >> /etc/postgresql/${version_major}/main/postgresql.conf \
+        && echo "host   all all 0.0.0.0/0        trust" > /etc/postgresql/${version_major}/main/pg_hba.conf \
+        && echo "host   all all ::/0             trust" >> /etc/postgresql/${version_major}/main/pg_hba.conf \
+        && echo "host   all all ::1/128          trust" >> /etc/postgresql/${version_major}/main/pg_hba.conf \
+        && sudo -H -u postgres sh -c "/usr/lib/postgresql/${version_major}/bin/initdb -D $PGDATA --auth-local trust --auth-host scram-sha-256"
+else
+    echo "PostgreSQL database already initialized, skipping initialization"
+fi
+
+echo "Starting PostgreSQL..."
+sudo /etc/init.d/postgresql start \
     && pg_isready -t 60
 
 set +e


### PR DESCRIPTION
Before this commit, PostgreSQL would only start when devcontainer is initially created and not start when already existing devcontainer is rebuilt or restarted.

The issue is that `initdb` fails when encounters already initialized directory. To avoid failure, only initialize db directory once.