### PR TITLE
Fix postgresql not allowing connections after container is recreated

### DIFF
--- a/src/postgresql/install.sh
+++ b/src/postgresql/install.sh
@@ -65,7 +65,7 @@ echo "listen_addresses = '*'" >> /etc/postgresql/${version_major}/main/postgresq
     && echo "data_directory = '$PGDATA'" >> /etc/postgresql/${version_major}/main/postgresql.conf \
     && echo "host   all all 0.0.0.0/0        trust" > /etc/postgresql/${version_major}/main/pg_hba.conf \
     && echo "host   all all ::/0             trust" >> /etc/postgresql/${version_major}/main/pg_hba.conf \
-    && echo "host   all all ::1/128          trust" >> /etc/postgresql/${version_major}/main/pg_hba.conf \
+    && echo "host   all all ::1/128          trust" >> /etc/postgresql/${version_major}/main/pg_hba.conf
 
 if [ ! -f "$PGDATA/PG_VERSION" ]; then
     echo "Initializing PostgreSQL database..."

--- a/src/postgresql/install.sh
+++ b/src/postgresql/install.sh
@@ -61,15 +61,16 @@ set -e
 
 version_major=$(psql --version | sed -z "s/psql (PostgreSQL) //g" | grep -Eo -m 1 "^([0-9]+)" | sed -z "s/-//g")
 
+echo "listen_addresses = '*'" >> /etc/postgresql/${version_major}/main/postgresql.conf \
+    && echo "data_directory = '$PGDATA'" >> /etc/postgresql/${version_major}/main/postgresql.conf \
+    && echo "host   all all 0.0.0.0/0        trust" > /etc/postgresql/${version_major}/main/pg_hba.conf \
+    && echo "host   all all ::/0             trust" >> /etc/postgresql/${version_major}/main/pg_hba.conf \
+    && echo "host   all all ::1/128          trust" >> /etc/postgresql/${version_major}/main/pg_hba.conf \
+
 if [ ! -f "$PGDATA/PG_VERSION" ]; then
     echo "Initializing PostgreSQL database..."
     chown -R postgres:postgres $PGDATA \
         && chmod 0750 $PGDATA \
-        && echo "listen_addresses = '*'" >> /etc/postgresql/${version_major}/main/postgresql.conf \
-        && echo "data_directory = '$PGDATA'" >> /etc/postgresql/${version_major}/main/postgresql.conf \
-        && echo "host   all all 0.0.0.0/0        trust" > /etc/postgresql/${version_major}/main/pg_hba.conf \
-        && echo "host   all all ::/0             trust" >> /etc/postgresql/${version_major}/main/pg_hba.conf \
-        && echo "host   all all ::1/128          trust" >> /etc/postgresql/${version_major}/main/pg_hba.conf \
         && sudo -H -u postgres sh -c "/usr/lib/postgresql/${version_major}/bin/initdb -D $PGDATA --auth-local trust --auth-host scram-sha-256"
 else
     echo "PostgreSQL database already initialized, skipping initialization"


### PR DESCRIPTION
This is a follow-up to #34

While #34 properly handles database initialization, we still need to write settings to pg_hba.conf because they are not persisted across container restarts

Closes #36