### PR TITLE
#44 fix: adding ms-ossdata.vscode-pgsql

### DIFF
--- a/src/postgresql/devcontainer-feature.json
+++ b/src/postgresql/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "PostgreSQL",
     "id": "postgresql",
-    "version": "1.6.1",
+    "version": "1.6.2",
     "description": "PostgreSQL is a powerful, open source object-relational database system with over 35 years of active development that has earned it a strong reputation for reliability, feature robustness, and performance.",
     "options": {
         "version": {
@@ -37,7 +37,7 @@
     "customizations": {
         "vscode": {
             "extensions": [
-                "ms-ossdata.vscode-postgresql"
+                "ms-ossdata.vscode-pgsql"
             ]
         }
     },


### PR DESCRIPTION
Updating the VScode plugin extension to remove the deprecated extension.